### PR TITLE
Update cell_assembly_detection.py

### DIFF
--- a/elephant/cell_assembly_detection.py
+++ b/elephant/cell_assembly_detection.py
@@ -88,7 +88,7 @@ __all__ = [
                   min_occ='min_occurrences',
                   same_config_cut='same_configuration_pruning')
 def cell_assembly_detection(binned_spiketrain, max_lag, reference_lag=2,
-                            alpha=0.05, min_occurrences=1, size_chunks=100,
+                            alph=0.05, min_occurrences=1, size_chunks=100,
                             max_spikes=np.inf, significance_pruning=True,
                             subgroup_pruning=True,
                             same_configuration_pruning=False,
@@ -252,7 +252,7 @@ def cell_assembly_detection(binned_spiketrain, max_lag, reference_lag=2,
     # divide alpha by the number of tests performed in the first
     # pairwise testing loop
     number_test_performed = n_neurons * (n_neurons - 1) * (2 * max_lag + 1)
-    alpha = alpha * 2 / float(number_test_performed)
+    alpha = alph * 2 / float(number_test_performed)
     if verbose:
         print('actual significance_level', alpha)
 
@@ -360,7 +360,7 @@ def cell_assembly_detection(binned_spiketrain, max_lag, reference_lag=2,
         if w2_to_test:
 
             # bonferroni correction only for the tests actually performed
-            alpha = alpha / float(len(w2_to_test) * n_as * (2 * max_lag + 1))
+            alpha = alph / float(len(w2_to_test) * n_as * (2 * max_lag + 1))
 
             # testing for the element in w2_to_test
             for ww2 in range(len(w2_to_test)):


### PR DESCRIPTION
alpha parameter in the " # testing for higher order assemblies" part gives the wrong value as it should take the original alpha=0.05 in the right side.
alpha = alpha / float(len(w2_to_test) * n_as * (2 * max_lag + 1))
As alpha in previous lines recalled and its value is changed because of same alpha values in both side of equation, it should be changed in a way that the value of alpha in the right side always is be the same is the alpha input parameter.
alpha parameter name in input parameter changed to alph in order to be constant and alpha parameter in the right side of alpha = alph/ float(len(w2_to_test) * n_as * (2 * max_lag + 1)) changes to alph. In this case, the alpha value in the right side is always constant and get the entered value in input. This simple change, will cause to get correct outputs based on the proposed algorithm.